### PR TITLE
[gopigo] Makefile fixes for macOS

### DIFF
--- a/makefiles/buildexe.mk
+++ b/makefiles/buildexe.mk
@@ -101,7 +101,7 @@ buildlibs:
 cleanlibs:
 	$(QUIET)for libdir in $(ALLLIBLIST) ; do \
 		cd $$libdir ; \
-		make --no-print-directory clean ;\
+		CONFIG=$(CONFIG) PLATFORM=$(PLATFORM) make --no-print-directory clean ;\
 	done
 
 ifeq ($(PLATFORM),GOPIGO)

--- a/makefiles/compiler.mk
+++ b/makefiles/compiler.mk
@@ -6,6 +6,7 @@ COMPILERSETUP=
 
 ifeq ($(MYCOMPILER),PI)
 CXX = arm-linux-gnueabihf-g++
+AR = arm-linux-gnueabihf-ar
 CXXFLAGS=$(LOCAL_CFLAGS) -Wno-psabi
 COMPILERSETUP=true
 EXEEXT=

--- a/makefiles/platform.mk
+++ b/makefiles/platform.mk
@@ -5,7 +5,7 @@
 
 ifeq ($(PLATFORM),GOPIGO)
 CXXFLAGS += -DGOPIGO
-PLATFORMLIBS=-lwiringPI -lpthread -latomic
+PLATFORMLIBS=-lwiringPi -lpthread -latomic
 endif
 
 ifeq ($(PLATFORM),SIMULATOR)


### PR DESCRIPTION
Fixes several errors I was running into on Mac:

- buildexe.mk: in `cleanlibs`, pass config & platform variables onto each library so they don't have to be manually specified as environment variables
- compiler.mk: use `ar` from toolchain instead of system, since the built-in ar on macOS is incompatible with RPi
- platform.mk: `-lwiringPi` flag is case-sensitive on my machine

Should probably be tested on Windows before merge (just to be sure it didn't break anything).