### PR TITLE
[MotorEncoderSubsystem] Wrapping compensation

### DIFF
--- a/robots/ranseur/src/main/cpp/tubwrist/TubWrist.cpp
+++ b/robots/ranseur/src/main/cpp/tubwrist/TubWrist.cpp
@@ -14,7 +14,6 @@ namespace xero {
       
     TubWrist::TubWrist(Subsystem *parent) : MotorEncoderSubsystem(parent, "tubwrist", "tubwrist", MSG_GROUP_TUBWRIST) {
             setSmartDashboardName("TubWrist") ;
-            setSpecialCaseFixMe() ;
         }
 
         TubWrist::~TubWrist() {

--- a/robots/ranseur/src/main/deploy/ranseur.dat
+++ b/robots/ranseur/src/main/deploy/ranseur.dat
@@ -36,7 +36,9 @@ hw:tubwrist:motor:canid                                         7
 hw:tubwrist:motor:type                                          "victor_spx"
 hw:tubwrist:encoder:analog                                      0
 hw:tubwrist:encoder:analog:m                                    71.5
-hw:tubwrist:encoder:analog:b                                    -168
+hw:tubwrist:encoder:analog:b                                    -96.5
+hw:tubwrist:encoder:analog:offset                               1.0
+hw:tubwrist:encoder:analog:wrap                                 5.0
 
 hw:tankdrive:motors:left:1:canid                                1
 hw:tankdrive:motors:left:2:canid                                2

--- a/xerolibs/xerobase/motorencodersubsystem/MotorEncoderSubsystem.cpp
+++ b/xerolibs/xerobase/motorencodersubsystem/MotorEncoderSubsystem.cpp
@@ -20,8 +20,7 @@ namespace xero {
         ): SingleMotorSubsystem(parent, name, "hw:" + config + ":motor", id), 
         speedometer_(/*samples=*/2, angular), configName_(name), msg_id_(id) {
             auto &robot = getRobot(); 
-            encoder_ = std::make_shared<XeroEncoder>(robot.getMessageLogger(), 
-                                                     robot.getSettingsParser(), 
+            encoder_ = std::make_shared<XeroEncoder>(robot,
                                                      "hw:" + config + ":encoder",
                                                      angular);
 

--- a/xerolibs/xerobase/motorencodersubsystem/MotorEncoderSubsystem.h
+++ b/xerolibs/xerobase/motorencodersubsystem/MotorEncoderSubsystem.h
@@ -34,10 +34,6 @@ namespace xero {
 
             double getPosition() { return speedometer_.getDistance(); }
 
-            void setSpecialCaseFixMe() {
-                encoder_->setSpecialCaseFixMe() ;
-            }
-
             xero::misc::Speedometer &getSpeedometer() { return speedometer_; }
             bool isAngular() { return encoder_->isAngular(); }
 

--- a/xerolibs/xerobase/motorencodersubsystem/XeroEncoder.cpp
+++ b/xerolibs/xerobase/motorencodersubsystem/XeroEncoder.cpp
@@ -13,7 +13,10 @@ namespace xero {
             assert(0);
         }
 
-        XeroEncoder::XeroEncoder(MessageLogger &logger, SettingsParser &parser, const std::string &configName, bool angular) {
+        XeroEncoder::XeroEncoder(Robot &robot, const std::string &configName, bool angular): robot_(robot) {
+            auto &logger = robot.getMessageLogger();
+            auto &parser = robot.getSettingsParser();
+
             angular_ = angular;
             
             name_ = configName ;
@@ -87,7 +90,9 @@ namespace xero {
             if (analog_) pos = analog_->GetVoltage();
             else if (pwm_) pos = pwm_->GetPeriod();
             else assert(0 == "no absolute encoder found");
-            frc::SmartDashboard::PutNumber(name_, pos) ;
+
+            // If the robot is disabled, output the raw hardware value for characterization
+            if (robot_.IsDisabled()) frc::SmartDashboard::PutNumber(name_, pos) ;
 
             // Compensate for encoder wrapping.
             pos = fmod(pos - absOffset_, absWrap_);

--- a/xerolibs/xerobase/motorencodersubsystem/XeroEncoder.h
+++ b/xerolibs/xerobase/motorencodersubsystem/XeroEncoder.h
@@ -85,33 +85,39 @@ namespace xero {
             /// @brief Creates a quadrature encoder.
             /// If angular is true, it is assumed the position is in degrees and the
             /// values are normalized to be between -180 and +180 degrees.
+            /// @param robot The robot.
+            /// @param name The name of the encoder (displayed on the smart dashboard for characterization)
             /// @param quadratureEncoder an FRC quadrature encoder object
             /// @param angular true if this encoder measures an angle
-            XeroEncoder(Robot &robot,
+            XeroEncoder(Robot &robot, std::string name,
                         std::shared_ptr<frc::Encoder> quadratureEncoder, bool angular = false
-            ): robot_(robot), angular_(angular), quad_(quadratureEncoder) {}
+            ): robot_(robot), name_(name), angular_(angular), quad_(quadratureEncoder) {}
 
             /// Creates an analog encoder, or a quadrature encoder calibrated by an analog encoder.
+            /// @param robot The robot.
+            /// @param name The name of the encoder (displayed on the smart dashboard for characterization)
             /// @param analogEncoder The analog input to which the encoder is connected.
             /// @param quadratureEncoder The quadrature encoder object, or \c nullptr to use just an analog encoder.
             /// @param angular true if this encoder measures an angle
-            XeroEncoder(Robot &robot,
+            XeroEncoder(Robot &robot, std::string name,
                         std::shared_ptr<frc::AnalogInput> analogEncoder,
                         std::shared_ptr<frc::Encoder>     quadratureEncoder = nullptr,
                         bool angular = false
-            ):  robot_(robot), angular_(angular), 
-                quad_(quadratureEncoder), analog_(analogEncoder) {}
+            ):  robot_(robot), name_(name),
+                angular_(angular), quad_(quadratureEncoder), analog_(analogEncoder) {}
 
             /// Creates a PWM encoder, or a quadrature encoder calibrated by a PWM encoder.
+            /// @param robot The robot.
+            /// @param name The name of the encoder (displayed on the smart dashboard for characterization)
             /// @param quadratureEncoder The quadrature encoder object, or \c nullptr to use just a PWM encoder.
             /// @param pwmEncoder A \c Counter measuring the signal from the PWM encoder.
             /// @param angular true if this encoder measures an angle
-            XeroEncoder(Robot &robot,
+            XeroEncoder(Robot &robot, std::string name,
                         std::shared_ptr<frc::Counter> pwmEncoder,
                         std::shared_ptr<frc::Encoder> quadratureEncoder = nullptr,
                         bool angular = false
-            ):  robot_(robot), angular_(angular), 
-                quad_(quadratureEncoder), pwm_(pwmEncoder) 
+            ):  robot_(robot), name_(name), 
+                angular_(angular), quad_(quadratureEncoder), pwm_(pwmEncoder) 
                 { pwm_->SetSemiPeriodMode(true); }
 
             /// @brief Returns true if this is measuring an angle
@@ -213,6 +219,8 @@ namespace xero {
         private:
             Robot &robot_;
 
+            std::string name_ ;
+
             bool angular_;
 
             std::shared_ptr<frc::Encoder> quad_;    // A quadrature encoder, or nullptr.
@@ -231,8 +239,6 @@ namespace xero {
             // The wrap point of the absolute encoder
             // (i.e. the maximum value output by the hardware).
             double absWrap_ = INFINITY;
-
-            std::string name_ ;
         };
     }
 }

--- a/xerolibs/xerobase/motorencodersubsystem/XeroEncoder.h
+++ b/xerolibs/xerobase/motorencodersubsystem/XeroEncoder.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <memory>
 
+#include <Robot.h>
 #include <SettingsParser.h>
 #include <MessageLogger.h>
 #include <frc/Encoder.h>
@@ -73,14 +74,12 @@ namespace xero {
             /// the class.\n 
             /// This class supports calibration is the act of ensuring that the position returned from the
             /// encoder matches the position of the mechanism being monitored on the robot.  Calibration 
-            /// @param logger The message logger.
-            /// @param settings The settings parser.
+            /// @param logger The robot.
             /// @param configName The name of the encoder in the configuration file.
             /// @param angular true if the encoder is angular
-            XeroEncoder(xero::misc::MessageLogger &logger,
-                    xero::misc::SettingsParser &settings, 
-                    const std::string &configName,
-                    bool angular = false
+            XeroEncoder(Robot &robot, 
+                        const std::string &configName,
+                        bool angular = false
             );
 
             /// @brief Creates a quadrature encoder.
@@ -88,26 +87,32 @@ namespace xero {
             /// values are normalized to be between -180 and +180 degrees.
             /// @param quadratureEncoder an FRC quadrature encoder object
             /// @param angular true if this encoder measures an angle
-            XeroEncoder(std::shared_ptr<frc::Encoder> quadratureEncoder, bool angular = false
-            ): angular_(angular), quad_(quadratureEncoder) {}
+            XeroEncoder(Robot &robot,
+                        std::shared_ptr<frc::Encoder> quadratureEncoder, bool angular = false
+            ): robot_(robot), angular_(angular), quad_(quadratureEncoder) {}
 
             /// Creates an analog encoder, or a quadrature encoder calibrated by an analog encoder.
             /// @param analogEncoder The analog input to which the encoder is connected.
             /// @param quadratureEncoder The quadrature encoder object, or \c nullptr to use just an analog encoder.
             /// @param angular true if this encoder measures an angle
-            XeroEncoder(std::shared_ptr<frc::AnalogInput> analogEncoder,
+            XeroEncoder(Robot &robot,
+                        std::shared_ptr<frc::AnalogInput> analogEncoder,
                         std::shared_ptr<frc::Encoder>     quadratureEncoder = nullptr,
                         bool angular = false
-            ): angular_(angular), quad_(quadratureEncoder), analog_(analogEncoder) {}
+            ):  robot_(robot), angular_(angular), 
+                quad_(quadratureEncoder), analog_(analogEncoder) {}
 
             /// Creates a PWM encoder, or a quadrature encoder calibrated by a PWM encoder.
             /// @param quadratureEncoder The quadrature encoder object, or \c nullptr to use just a PWM encoder.
             /// @param pwmEncoder A \c Counter measuring the signal from the PWM encoder.
             /// @param angular true if this encoder measures an angle
-            XeroEncoder(std::shared_ptr<frc::Counter> pwmEncoder,
+            XeroEncoder(Robot &robot,
+                        std::shared_ptr<frc::Counter> pwmEncoder,
                         std::shared_ptr<frc::Encoder> quadratureEncoder = nullptr,
                         bool angular = false
-            ): angular_(angular), quad_(quadratureEncoder), pwm_(pwmEncoder) { pwm_->SetSemiPeriodMode(true); }
+            ):  robot_(robot), angular_(angular), 
+                quad_(quadratureEncoder), pwm_(pwmEncoder) 
+                { pwm_->SetSemiPeriodMode(true); }
 
             /// @brief Returns true if this is measuring an angle
             /// @returns true if this is measuring an angle
@@ -206,6 +211,8 @@ namespace xero {
                 absB_ = b;
             }
         private:
+            Robot &robot_;
+
             bool angular_;
 
             std::shared_ptr<frc::Encoder> quad_;    // A quadrature encoder, or nullptr.
@@ -226,7 +233,6 @@ namespace xero {
             double absWrap_ = INFINITY;
 
             std::string name_ ;
-
         };
     }
 }


### PR DESCRIPTION
Adds the ability to compensate for absolute encoders wrapping mid-range. Documented in XeroEncoder.h.